### PR TITLE
Fix type safety, migration safety, and test coverage for update-status

### DIFF
--- a/src/auth/decorators/current-user.decorator.ts
+++ b/src/auth/decorators/current-user.decorator.ts
@@ -1,4 +1,5 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { User } from '../../users/entities/user.entity';
 
 export interface JwtPayload {
   sub: string;
@@ -8,10 +9,8 @@ export interface JwtPayload {
 }
 
 export const CurrentUser = createParamDecorator(
-  (data: unknown, ctx: ExecutionContext): JwtPayload => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const request = ctx.switchToHttp().getRequest();
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    return request.user as JwtPayload;
+  (_data: unknown, ctx: ExecutionContext): User => {
+    const request = ctx.switchToHttp().getRequest<{ user: User }>();
+    return request.user;
   },
 );

--- a/src/auth/guards/policies.guard.ts
+++ b/src/auth/guards/policies.guard.ts
@@ -6,10 +6,8 @@ import { User } from '../../users/entities/user.entity';
 import { AppAbility, CaslAbilityFactory } from '../casl/casl-ability.factory';
 import { PolicyHandler } from '../casl/policy-handler.interface';
 import { CHECK_POLICIES_KEY } from '../decorators/check-policies.decorator';
-import { JwtPayload } from '../decorators/current-user.decorator';
-
 interface RequestWithUser {
-  user: JwtPayload;
+  user: User;
 }
 
 @Injectable()
@@ -33,7 +31,7 @@ export class PoliciesGuard implements CanActivate {
     }
 
     const request = context.switchToHttp().getRequest<RequestWithUser>();
-    const userId = request.user?.sub;
+    const userId = request.user?.id;
 
     if (!userId) {
       return false; // No user ID in the request, access denied

--- a/src/database/migrations/1770000000000-EnforceItemListRelationship.ts
+++ b/src/database/migrations/1770000000000-EnforceItemListRelationship.ts
@@ -6,6 +6,7 @@ export class EnforceItemListRelationship1770000000000
   name = 'EnforceItemListRelationship1770000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DELETE FROM "items" WHERE "listId" IS NULL');
     await queryRunner.query(
       'ALTER TABLE "items" ALTER COLUMN "listId" SET NOT NULL',
     );

--- a/src/lists/lists.controller.ts
+++ b/src/lists/lists.controller.ts
@@ -18,10 +18,7 @@ import { UpdateListDto } from './dto/update-list.dto';
 import { ActionOnResource } from '../auth/decorators/action-on-resource.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RoleName } from '../roles/entities/role.entity';
-import {
-  CurrentUser,
-  JwtPayload,
-} from '../auth/decorators/current-user.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { User } from '../users/entities/user.entity';
 
 @Controller('lists')
@@ -30,22 +27,19 @@ export class ListsController {
 
   @Post()
   @ActionOnResource({ roles: [RoleName.ADMIN] })
-  create(
-    @Body() createListDto: CreateListDto,
-    @CurrentUser() user: JwtPayload,
-  ) {
-    return this.listsService.create(createListDto, user.sub);
+  create(@Body() createListDto: CreateListDto, @CurrentUser() user: User) {
+    return this.listsService.create(createListDto, user.id);
   }
 
   @Get()
   @UseGuards(JwtAuthGuard)
   findAll(
-    @CurrentUser() user: JwtPayload,
+    @CurrentUser() user: User,
     @Query(new ValidationPipe({ transform: true, whitelist: true }))
     paginationQuery: ListPaginationQueryDto,
   ) {
     return this.listsService.findAll(
-      user.sub,
+      user.id,
       paginationQuery.page,
       paginationQuery.limit,
     );
@@ -53,11 +47,8 @@ export class ListsController {
 
   @Get(':id')
   @UseGuards(JwtAuthGuard)
-  findOne(
-    @Param('id', ParseUUIDPipe) id: string,
-    @CurrentUser() user: JwtPayload,
-  ) {
-    return this.listsService.findOne(id, user.sub);
+  findOne(@Param('id', ParseUUIDPipe) id: string, @CurrentUser() user: User) {
+    return this.listsService.findOne(id, user.id);
   }
 
   @Patch(':id')

--- a/src/lists/test/lists.controller.spec.ts
+++ b/src/lists/test/lists.controller.spec.ts
@@ -4,7 +4,6 @@ import { ListsController } from '../lists.controller';
 import { ListsService } from '../lists.service';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { User } from '../../users/entities/user.entity';
-import { JwtPayload } from '../../auth/decorators/current-user.decorator';
 
 describe('ListsController', () => {
   let controller: ListsController;
@@ -38,11 +37,11 @@ describe('ListsController', () => {
   });
 
   describe('findAll', () => {
-    const user: JwtPayload = {
-      sub: '9e1e4ec1-7b89-456b-9e5a-2d84a58d241b',
+    const user = {
+      id: '9e1e4ec1-7b89-456b-9e5a-2d84a58d241b',
       email: 'owner@example.com',
       username: 'owner',
-    };
+    } as User;
 
     it('should scope results to the current user', async () => {
       const ownedLists = {
@@ -50,7 +49,7 @@ describe('ListsController', () => {
           {
             id: 'e763d4ac-f0ca-4867-9dfc-68607143ac2d',
             title: 'Daily wins',
-            userId: user.sub,
+            userId: user.id,
           },
         ],
         meta: {
@@ -69,7 +68,7 @@ describe('ListsController', () => {
 
       expect(result).toBe(ownedLists);
       expect(mockListsService.findAll).toHaveBeenCalledTimes(1);
-      expect(mockListsService.findAll).toHaveBeenCalledWith(user.sub, 1, 10);
+      expect(mockListsService.findAll).toHaveBeenCalledWith(user.id, 1, 10);
     });
 
     it('passes pagination params to the service', async () => {
@@ -88,23 +87,23 @@ describe('ListsController', () => {
 
       const result = await controller.findAll(user, { page: 2, limit: 5 });
 
-      expect(mockListsService.findAll).toHaveBeenCalledWith(user.sub, 2, 5);
+      expect(mockListsService.findAll).toHaveBeenCalledWith(user.id, 2, 5);
       expect(result).toBe(paginatedResponse);
     });
   });
 
   describe('findOne', () => {
     it('should return a list only after validating ownership for the current user', async () => {
-      const user: JwtPayload = {
-        sub: '9e1e4ec1-7b89-456b-9e5a-2d84a58d241b',
+      const user = {
+        id: '9e1e4ec1-7b89-456b-9e5a-2d84a58d241b',
         email: 'owner@example.com',
         username: 'owner',
-      };
+      } as User;
       const listId = 'e763d4ac-f0ca-4867-9dfc-68607143ac2d';
       const ownedList = {
         id: listId,
         title: 'Daily wins',
-        userId: user.sub,
+        userId: user.id,
       };
 
       mockListsService.findOne.mockResolvedValue(ownedList);
@@ -113,7 +112,7 @@ describe('ListsController', () => {
 
       expect(result).toBe(ownedList);
       expect(mockListsService.findOne).toHaveBeenCalledTimes(1);
-      expect(mockListsService.findOne).toHaveBeenCalledWith(listId, user.sub);
+      expect(mockListsService.findOne).toHaveBeenCalledWith(listId, user.id);
     });
   });
 });

--- a/src/moods/moods.controller.ts
+++ b/src/moods/moods.controller.ts
@@ -15,10 +15,8 @@ import { UpdateMoodDto } from './dto/update-mood.dto';
 import { ActionOnResource } from '../auth/decorators/action-on-resource.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RoleName } from '../roles/entities/role.entity';
-import {
-  CurrentUser,
-  JwtPayload,
-} from '../auth/decorators/current-user.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { User } from '../users/entities/user.entity';
 
 @Controller('moods')
 export class MoodsController {
@@ -26,11 +24,8 @@ export class MoodsController {
 
   @Post()
   @ActionOnResource({ roles: [RoleName.ADMIN] })
-  create(
-    @Body() createMoodDto: CreateMoodDto,
-    @CurrentUser() user: JwtPayload,
-  ) {
-    return this.moodsService.create(createMoodDto, user.sub);
+  create(@Body() createMoodDto: CreateMoodDto, @CurrentUser() user: User) {
+    return this.moodsService.create(createMoodDto, user.id);
   }
 
   @Get()

--- a/test/items.e2e-spec.ts
+++ b/test/items.e2e-spec.ts
@@ -3,8 +3,10 @@
 import {
   CanActivate,
   ExecutionContext,
+  ForbiddenException,
   INestApplication,
   Module,
+  NotFoundException,
   UnauthorizedException,
   ValidationPipe,
 } from '@nestjs/common';
@@ -26,6 +28,7 @@ const mockItemsService = {
   findAll: jest.fn(),
   findOne: jest.fn(),
   update: jest.fn(),
+  updateStatus: jest.fn(),
   remove: jest.fn(),
 };
 
@@ -52,6 +55,11 @@ class FakeJwtAuthGuard implements CanActivate {
 
     if (authHeader === 'Bearer user-token') {
       request.user = { id: 'regular-user-id', sub: 'regular-user-id' };
+      return true;
+    }
+
+    if (authHeader === 'Bearer owner-token') {
+      request.user = { id: 'owner-user-id', sub: 'owner-user-id' };
       return true;
     }
 
@@ -196,6 +204,92 @@ describe('ItemsController (e2e)', () => {
         .expect(items);
 
       expect(mockItemsService.findAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('PATCH /items/:id/status', () => {
+    const itemId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    const validPayload = { status: STATUS.IN_PROGRESS };
+
+    it('returns 401 when no token is provided', async () => {
+      await request(app.getHttpServer())
+        .patch(`/items/${itemId}/status`)
+        .send(validPayload)
+        .expect(401);
+
+      expect(mockItemsService.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for an invalid status value', async () => {
+      await request(app.getHttpServer())
+        .patch(`/items/${itemId}/status`)
+        .set('Authorization', 'Bearer user-token')
+        .send({ status: 'invalid-status' })
+        .expect(400);
+
+      expect(mockItemsService.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the item does not exist', async () => {
+      mockItemsService.updateStatus.mockRejectedValue(
+        new NotFoundException(`Item with id ${itemId} not found`),
+      );
+
+      await request(app.getHttpServer())
+        .patch(`/items/${itemId}/status`)
+        .set('Authorization', 'Bearer user-token')
+        .send(validPayload)
+        .expect(404);
+    });
+
+    it('returns 403 when the user is not the list owner and not an admin', async () => {
+      mockItemsService.updateStatus.mockRejectedValue(
+        new ForbiddenException(
+          'You are not allowed to update this item status',
+        ),
+      );
+
+      await request(app.getHttpServer())
+        .patch(`/items/${itemId}/status`)
+        .set('Authorization', 'Bearer user-token')
+        .send(validPayload)
+        .expect(403);
+    });
+
+    it('returns 200 when the user is an admin (not the list owner)', async () => {
+      const updatedItem = { id: itemId, ...validPayload };
+      mockItemsService.updateStatus.mockResolvedValue(updatedItem);
+
+      await request(app.getHttpServer())
+        .patch(`/items/${itemId}/status`)
+        .set('Authorization', 'Bearer admin-token')
+        .send(validPayload)
+        .expect(200)
+        .expect(updatedItem);
+
+      expect(mockItemsService.updateStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'admin-user-id' }),
+        itemId,
+        validPayload,
+      );
+    });
+
+    it('returns 200 when the user is the list owner', async () => {
+      const updatedItem = { id: itemId, ...validPayload };
+      mockItemsService.updateStatus.mockResolvedValue(updatedItem);
+
+      await request(app.getHttpServer())
+        .patch(`/items/${itemId}/status`)
+        .set('Authorization', 'Bearer owner-token')
+        .send(validPayload)
+        .expect(200)
+        .expect(updatedItem);
+
+      expect(mockItemsService.updateStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'owner-user-id' }),
+        itemId,
+        validPayload,
+      );
     });
   });
 });


### PR DESCRIPTION
CurrentUser type fix
- [x] current-user.decorator.ts — decorator return type changed from JwtPayload to User; unsafe as JwtPayload cast removed; JwtPayload kept exported for jwt.strategy.ts validate() contract
- [x] lists.controller.ts — JwtPayload import removed; user: JwtPayload → user: User; user.sub → user.id (create, findAll, findOne)
- [x] moods.controller.ts — same: user: JwtPayload → user: User, user.sub → user.id
- [x] policies.guard.ts — RequestWithUser.user type changed from JwtPayload to User; request.user?.sub → request.user?.id; unused JwtPayload import removed
- [x] lists.controller.spec.ts — mock user fixtures updated from JwtPayload shape (sub) to User shape (id); JwtPayload import removed

Migration safety
- [x] 1770000000000-EnforceItemListRelationship.ts — DELETE FROM "items" WHERE "listId" IS NULL added before ALTER COLUMN "listId" SET NOT NULL to prevent deploy failure on environments with existing orphan rows

Test coverage
- [x] test/items.e2e-spec.ts — e2e suite added for PATCH /items/:id/status: 401 (no token), 400 (invalid status), 404 (item not found), 403 (not owner, not admin), 200 (admin), 200 (list owner)