### PR TITLE
Task-56: Scope Lists, Items, and Moods to the current user

### DIFF
--- a/src/common/authorization/owner-scoped-query.util.spec.ts
+++ b/src/common/authorization/owner-scoped-query.util.spec.ts
@@ -1,0 +1,50 @@
+import { getOwnerScopedWhere, isAdminUser } from './owner-scoped-query.util';
+import { RoleName } from '../../roles/entities/role.entity';
+import { User } from '../../users/entities/user.entity';
+
+describe('owner-scoped query utils', () => {
+  const admin = {
+    id: 'admin-id',
+    roles: [{ name: RoleName.ADMIN }],
+  } as User;
+
+  const regularUser = {
+    id: 'user-id',
+    roles: [{ name: RoleName.USER }],
+  } as User;
+
+  it('detects admin users', () => {
+    expect(isAdminUser(admin)).toBe(true);
+    expect(isAdminUser(regularUser)).toBe(false);
+  });
+
+  it('returns undefined owner scope for admins', () => {
+    expect(getOwnerScopedWhere(admin, { userId: admin.id })).toBeUndefined();
+  });
+
+  it('returns owner scope for regular users', () => {
+    expect(
+      getOwnerScopedWhere(regularUser, { userId: regularUser.id }),
+    ).toEqual({
+      userId: regularUser.id,
+    });
+  });
+
+  it('returns the admin where shape when one is provided', () => {
+    expect(
+      getOwnerScopedWhere(
+        admin,
+        { id: 'entity-id', userId: admin.id },
+        { id: 'entity-id' },
+      ),
+    ).toEqual({ id: 'entity-id' });
+
+    expect(
+      getOwnerScopedWhere(
+        regularUser,
+        { id: 'entity-id', userId: regularUser.id },
+        { id: 'entity-id' },
+      ),
+    ).toEqual({ id: 'entity-id', userId: regularUser.id });
+  });
+});

--- a/src/common/authorization/owner-scoped-query.util.ts
+++ b/src/common/authorization/owner-scoped-query.util.ts
@@ -1,0 +1,17 @@
+import { RoleName } from '../../roles/entities/role.entity';
+import { User } from '../../users/entities/user.entity';
+
+export function isAdminUser(user: User): boolean {
+  return user.roles?.some((role) => role.name === RoleName.ADMIN) ?? false;
+}
+
+export function getOwnerScopedWhere<
+  TOwnerWhere extends object,
+  TAdminWhere extends object | undefined = undefined,
+>(
+  currentUser: User,
+  ownerWhere: TOwnerWhere,
+  adminWhere?: TAdminWhere,
+): TOwnerWhere | TAdminWhere | undefined {
+  return isAdminUser(currentUser) ? adminWhere : ownerWhere;
+}

--- a/src/items/items.controller.ts
+++ b/src/items/items.controller.ts
@@ -47,8 +47,8 @@ export class ItemsController {
   @ApiOperation({ summary: 'Get all items' })
   @ApiResponse({ status: 200, description: 'Return all items.' })
   @UseGuards(JwtAuthGuard)
-  findAll() {
-    return this.itemsService.findAll();
+  findAll(@CurrentUser() currentUser: User) {
+    return this.itemsService.findAll(currentUser);
   }
 
   @Get(':id')
@@ -56,8 +56,11 @@ export class ItemsController {
   @ApiParam({ name: 'id', description: 'Item ID' })
   @ApiResponse({ status: 200, description: 'Return the item.' })
   @UseGuards(JwtAuthGuard)
-  findOne(@Param('id', ParseUUIDPipe) id: string) {
-    return this.itemsService.findOne(id);
+  findOne(
+    @CurrentUser() currentUser: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    return this.itemsService.findOne(id, currentUser);
   }
 
   @Patch(':id/status')

--- a/src/items/items.service.ts
+++ b/src/items/items.service.ts
@@ -10,8 +10,11 @@ import { UpdateItemDto } from './dto/update-item.dto';
 import { UpdateItemStatusDto } from './dto/update-item-status.dto';
 import { Item } from './entities/item.entity';
 import { User } from '../users/entities/user.entity';
-import { RoleName } from '../roles/entities/role.entity';
 import { List } from '../lists/entities/list.entity';
+import {
+  getOwnerScopedWhere,
+  isAdminUser,
+} from '../common/authorization/owner-scoped-query.util';
 
 @Injectable()
 export class ItemsService {
@@ -32,12 +35,26 @@ export class ItemsService {
     return this.itemRepository.save(newItem);
   }
 
-  findAll(): Promise<Item[]> {
-    return this.itemRepository.find();
+  findAll(currentUser: User): Promise<Item[]> {
+    const where = getOwnerScopedWhere(currentUser, {
+      list: { userId: currentUser.id },
+    });
+
+    return this.itemRepository.find({
+      where,
+    });
   }
 
-  async findOne(id: string): Promise<Item> {
-    const item = await this.itemRepository.findOne({ where: { id } });
+  async findOne(id: string, currentUser: User): Promise<Item> {
+    const where = getOwnerScopedWhere(
+      currentUser,
+      { id, list: { userId: currentUser.id } },
+      { id },
+    );
+
+    const item = await this.itemRepository.findOne({
+      where,
+    });
 
     if (!item) {
       throw new NotFoundException(`Item with id ${id} not found`);
@@ -47,7 +64,7 @@ export class ItemsService {
   }
 
   async update(id: string, updateItemDto: UpdateItemDto): Promise<Item> {
-    const item = await this.findOne(id);
+    const item = await this.findOneById(id);
 
     if (updateItemDto.listId) {
       await this.ensureListExists(updateItemDto.listId);
@@ -72,9 +89,7 @@ export class ItemsService {
       throw new NotFoundException(`Item with id ${id} not found`);
     }
 
-    const isAdmin = currentUser.roles?.some(
-      (role) => role.name === RoleName.ADMIN,
-    );
+    const isAdmin = isAdminUser(currentUser);
     const isListOwner = item.list?.userId === currentUser.id;
 
     if (!isAdmin && !isListOwner) {
@@ -104,5 +119,15 @@ export class ItemsService {
     if (!list) {
       throw new NotFoundException(`List with id ${listId} not found`);
     }
+  }
+
+  private async findOneById(id: string): Promise<Item> {
+    const item = await this.itemRepository.findOne({ where: { id } });
+
+    if (!item) {
+      throw new NotFoundException(`Item with id ${id} not found`);
+    }
+
+    return item;
   }
 }

--- a/src/items/test/items.controller.spec.ts
+++ b/src/items/test/items.controller.spec.ts
@@ -45,6 +45,29 @@ describe('ItemsController', () => {
     expect(controller).toBeDefined();
   });
 
+  it('should delegate item list reads with the current user id', async () => {
+    const currentUser = { id: 'user-1' } as User;
+    const items = [{ id: 'item-id' }] as Item[];
+    const findAllSpy = jest.spyOn(service, 'findAll').mockResolvedValue(items);
+
+    const result = await controller.findAll(currentUser);
+
+    expect(findAllSpy).toHaveBeenCalledWith(currentUser);
+    expect(result).toEqual(items);
+  });
+
+  it('should delegate single item reads with the current user id', async () => {
+    const itemId = '550e8400-e29b-41d4-a716-446655440000';
+    const currentUser = { id: 'user-1' } as User;
+    const item = { id: itemId } as Item;
+    const findOneSpy = jest.spyOn(service, 'findOne').mockResolvedValue(item);
+
+    const result = await controller.findOne(currentUser, itemId);
+
+    expect(findOneSpy).toHaveBeenCalledWith(itemId, currentUser);
+    expect(result).toEqual(item);
+  });
+
   it('should delegate item status updates to the service', async () => {
     const itemId = '550e8400-e29b-41d4-a716-446655440000';
     const updateItemStatusDto = { status: STATUS.IN_PROGRESS };

--- a/src/items/test/items.service.spec.ts
+++ b/src/items/test/items.service.spec.ts
@@ -93,6 +93,100 @@ describe('ItemsService', () => {
     expect(mockItemRepository.save).not.toHaveBeenCalled();
   });
 
+  it('should return only items owned by the current user', async () => {
+    const currentUser = {
+      id: 'user-uuid',
+      roles: [{ name: RoleName.USER }],
+    } as User;
+    const items = [
+      {
+        id: 'item-id',
+        list: { userId: currentUser.id },
+      },
+    ] as Item[];
+
+    mockItemRepository.find.mockResolvedValue(items);
+
+    const result = await service.findAll(currentUser);
+
+    expect(mockItemRepository.find).toHaveBeenCalledWith({
+      where: { list: { userId: currentUser.id } },
+    });
+    expect(result).toEqual(items);
+  });
+
+  it('should return items from all users for admins', async () => {
+    const currentUser = {
+      id: 'admin-uuid',
+      roles: [{ name: RoleName.ADMIN }],
+    } as User;
+    const items = [{ id: 'item-id' }] as Item[];
+
+    mockItemRepository.find.mockResolvedValue(items);
+
+    const result = await service.findAll(currentUser);
+
+    expect(mockItemRepository.find).toHaveBeenCalledWith({
+      where: undefined,
+    });
+    expect(result).toEqual(items);
+  });
+
+  it('should return one item only when it belongs to the current user', async () => {
+    const itemId = '550e8400-e29b-41d4-a716-446655440000';
+    const currentUser = {
+      id: 'user-uuid',
+      roles: [{ name: RoleName.USER }],
+    } as User;
+    const item = {
+      id: itemId,
+      list: { userId: currentUser.id },
+    } as Item;
+
+    mockItemRepository.findOne.mockResolvedValue(item);
+
+    const result = await service.findOne(itemId, currentUser);
+
+    expect(mockItemRepository.findOne).toHaveBeenCalledWith({
+      where: { id: itemId, list: { userId: currentUser.id } },
+    });
+    expect(result).toEqual(item);
+  });
+
+  it('should return one item by id for admins', async () => {
+    const itemId = '550e8400-e29b-41d4-a716-446655440000';
+    const currentUser = {
+      id: 'admin-uuid',
+      roles: [{ name: RoleName.ADMIN }],
+    } as User;
+    const item = {
+      id: itemId,
+    } as Item;
+
+    mockItemRepository.findOne.mockResolvedValue(item);
+
+    const result = await service.findOne(itemId, currentUser);
+
+    expect(mockItemRepository.findOne).toHaveBeenCalledWith({
+      where: { id: itemId },
+    });
+    expect(result).toEqual(item);
+  });
+
+  it('should reject when an item does not belong to the current user', async () => {
+    const itemId = '550e8400-e29b-41d4-a716-446655440000';
+    const currentUser = {
+      id: 'user-uuid',
+      roles: [{ name: RoleName.USER }],
+    } as User;
+
+    mockItemRepository.findOne.mockResolvedValue(null);
+
+    await expect(service.findOne(itemId, currentUser)).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
   it('should update only the item status', async () => {
     const item = {
       id: '550e8400-e29b-41d4-a716-446655440000',

--- a/src/lists/lists.controller.ts
+++ b/src/lists/lists.controller.ts
@@ -39,7 +39,7 @@ export class ListsController {
     paginationQuery: ListPaginationQueryDto,
   ) {
     return this.listsService.findAll(
-      user.id,
+      user,
       paginationQuery.page,
       paginationQuery.limit,
     );
@@ -48,7 +48,7 @@ export class ListsController {
   @Get(':id')
   @UseGuards(JwtAuthGuard)
   findOne(@Param('id', ParseUUIDPipe) id: string, @CurrentUser() user: User) {
-    return this.listsService.findOne(id, user.id);
+    return this.listsService.findOne(id, user);
   }
 
   @Patch(':id')

--- a/src/lists/lists.service.ts
+++ b/src/lists/lists.service.ts
@@ -6,6 +6,8 @@ import { PaginatedListsResponseDto } from './dto/paginated-lists-response.dto';
 import { UpdateListDto } from './dto/update-list.dto';
 import { List } from './entities/list.entity';
 import { IUpdateOperation } from 'src/types/update-operation.type.js';
+import { User } from '../users/entities/user.entity';
+import { getOwnerScopedWhere } from '../common/authorization/owner-scoped-query.util';
 
 @Injectable()
 export class ListsService {
@@ -23,12 +25,16 @@ export class ListsService {
   }
 
   async findAll(
-    userId: string,
+    currentUser: User,
     page = 1,
     limit = 10,
   ): Promise<PaginatedListsResponseDto> {
+    const where = getOwnerScopedWhere(currentUser, {
+      userId: currentUser.id,
+    });
+
     const [data, total] = await this.listRepository.findAndCount({
-      where: { userId },
+      where,
       order: { createdAt: 'DESC' },
       skip: (page - 1) * limit,
       take: limit,
@@ -48,8 +54,13 @@ export class ListsService {
     };
   }
 
-  async findOne(id: string, userId: string): Promise<List> {
-    const list = await this.listRepository.findOne({ where: { id, userId } });
+  async findOne(id: string, currentUser: User): Promise<List> {
+    const where = getOwnerScopedWhere(
+      currentUser,
+      { id, userId: currentUser.id },
+      { id },
+    );
+    const list = await this.listRepository.findOne({ where });
 
     if (!list) {
       throw new NotFoundException(`List with id ${id} not found`);
@@ -63,7 +74,7 @@ export class ListsService {
     id,
     dto: updateListDto,
   }: IUpdateOperation<UpdateListDto>): Promise<List> {
-    const list = await this.findOne(id, currentUser.id);
+    const list = await this.findOne(id, currentUser);
     const updated = this.listRepository.merge(list, updateListDto);
 
     return this.listRepository.save(updated);

--- a/src/lists/test/lists.controller.spec.ts
+++ b/src/lists/test/lists.controller.spec.ts
@@ -68,7 +68,7 @@ describe('ListsController', () => {
 
       expect(result).toBe(ownedLists);
       expect(mockListsService.findAll).toHaveBeenCalledTimes(1);
-      expect(mockListsService.findAll).toHaveBeenCalledWith(user.id, 1, 10);
+      expect(mockListsService.findAll).toHaveBeenCalledWith(user, 1, 10);
     });
 
     it('passes pagination params to the service', async () => {
@@ -87,7 +87,7 @@ describe('ListsController', () => {
 
       const result = await controller.findAll(user, { page: 2, limit: 5 });
 
-      expect(mockListsService.findAll).toHaveBeenCalledWith(user.id, 2, 5);
+      expect(mockListsService.findAll).toHaveBeenCalledWith(user, 2, 5);
       expect(result).toBe(paginatedResponse);
     });
   });
@@ -112,7 +112,7 @@ describe('ListsController', () => {
 
       expect(result).toBe(ownedList);
       expect(mockListsService.findOne).toHaveBeenCalledTimes(1);
-      expect(mockListsService.findOne).toHaveBeenCalledWith(listId, user.id);
+      expect(mockListsService.findOne).toHaveBeenCalledWith(listId, user);
     });
   });
 });

--- a/src/lists/test/lists.service.spec.ts
+++ b/src/lists/test/lists.service.spec.ts
@@ -3,6 +3,8 @@ import { NotFoundException } from '@nestjs/common';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { ListsService } from '../lists.service';
 import { List } from '../entities/list.entity';
+import { RoleName } from '../../roles/entities/role.entity';
+import { User } from '../../users/entities/user.entity';
 
 describe('ListsService', () => {
   let service: ListsService;
@@ -17,6 +19,8 @@ describe('ListsService', () => {
   };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ListsService,
@@ -35,14 +39,17 @@ describe('ListsService', () => {
   });
 
   it('returns paginated lists scoped to the current user', async () => {
-    const userId = 'user-uuid';
+    const currentUser = {
+      id: 'user-uuid',
+      roles: [{ name: RoleName.USER }],
+    } as User;
     const lists = [{ id: 'list-2' }, { id: 'list-1' }] as List[];
     mockListRepository.findAndCount.mockResolvedValue([lists, 5]);
 
-    const result = await service.findAll(userId, 2, 2);
+    const result = await service.findAll(currentUser, 2, 2);
 
     expect(mockListRepository.findAndCount).toHaveBeenCalledWith({
-      where: { userId },
+      where: { userId: currentUser.id },
       order: { createdAt: 'DESC' },
       skip: 2,
       take: 2,
@@ -60,10 +67,32 @@ describe('ListsService', () => {
     });
   });
 
+  it('returns paginated lists from all users for admins', async () => {
+    const currentUser = {
+      id: 'admin-uuid',
+      roles: [{ name: RoleName.ADMIN }],
+    } as User;
+    const lists = [{ id: 'list-2' }, { id: 'list-1' }] as List[];
+    mockListRepository.findAndCount.mockResolvedValue([lists, 5]);
+
+    await service.findAll(currentUser, 2, 2);
+
+    expect(mockListRepository.findAndCount).toHaveBeenCalledWith({
+      where: undefined,
+      order: { createdAt: 'DESC' },
+      skip: 2,
+      take: 2,
+    });
+  });
+
   it('returns both navigation flags as false when total is 0', async () => {
+    const currentUser = {
+      id: 'user-uuid',
+      roles: [{ name: RoleName.USER }],
+    } as User;
     mockListRepository.findAndCount.mockResolvedValue([[], 0]);
 
-    const result = await service.findAll('user-uuid', 2, 5);
+    const result = await service.findAll(currentUser, 2, 5);
 
     expect(result.meta).toMatchObject({
       total: 0,
@@ -73,11 +102,34 @@ describe('ListsService', () => {
     });
   });
 
-  it('throws when a list is not found', async () => {
+  it("returns 404 when a regular user requests another user's list", async () => {
+    const currentUser = {
+      id: 'user-uuid',
+      roles: [{ name: RoleName.USER }],
+    } as User;
     mockListRepository.findOne.mockResolvedValue(null);
 
-    await expect(service.findOne('missing-id', 'user-uuid')).rejects.toThrow(
-      new NotFoundException('List with id missing-id not found'),
+    await expect(service.findOne('other-list-id', currentUser)).rejects.toThrow(
+      new NotFoundException('List with id other-list-id not found'),
     );
+    expect(mockListRepository.findOne).toHaveBeenCalledWith({
+      where: { id: 'other-list-id', userId: currentUser.id },
+    });
+  });
+
+  it('finds one list by id only for admins', async () => {
+    const currentUser = {
+      id: 'admin-uuid',
+      roles: [{ name: RoleName.ADMIN }],
+    } as User;
+    const list = { id: 'list-id' } as List;
+    mockListRepository.findOne.mockResolvedValue(list);
+
+    const result = await service.findOne(list.id, currentUser);
+
+    expect(mockListRepository.findOne).toHaveBeenCalledWith({
+      where: { id: list.id },
+    });
+    expect(result).toBe(list);
   });
 });

--- a/src/moods/moods.controller.ts
+++ b/src/moods/moods.controller.ts
@@ -30,14 +30,17 @@ export class MoodsController {
 
   @Get()
   @UseGuards(JwtAuthGuard)
-  findAll() {
-    return this.moodsService.findAll();
+  findAll(@CurrentUser() currentUser: User) {
+    return this.moodsService.findAll(currentUser);
   }
 
   @Get(':id')
   @UseGuards(JwtAuthGuard)
-  findOne(@Param('id', ParseUUIDPipe) id: string) {
-    return this.moodsService.findOne(id);
+  findOne(
+    @CurrentUser() currentUser: User,
+    @Param('id', ParseUUIDPipe) id: string,
+  ) {
+    return this.moodsService.findOne(id, currentUser);
   }
 
   @Patch(':id')

--- a/src/moods/moods.service.ts
+++ b/src/moods/moods.service.ts
@@ -4,6 +4,8 @@ import { Repository } from 'typeorm';
 import { CreateMoodDto } from './dto/create-mood.dto';
 import { UpdateMoodDto } from './dto/update-mood.dto';
 import { Mood } from './entities/mood.entity';
+import { User } from '../users/entities/user.entity';
+import { getOwnerScopedWhere } from '../common/authorization/owner-scoped-query.util';
 
 @Injectable()
 export class MoodsService {
@@ -20,12 +22,21 @@ export class MoodsService {
     return this.moodRepository.save(mood);
   }
 
-  findAll(): Promise<Mood[]> {
-    return this.moodRepository.find();
+  findAll(currentUser: User): Promise<Mood[]> {
+    const where = getOwnerScopedWhere(currentUser, {
+      userId: currentUser.id,
+    });
+
+    return this.moodRepository.find({ where });
   }
 
-  async findOne(id: string): Promise<Mood> {
-    const mood = await this.moodRepository.findOne({ where: { id } });
+  async findOne(id: string, currentUser: User): Promise<Mood> {
+    const where = getOwnerScopedWhere(
+      currentUser,
+      { id, userId: currentUser.id },
+      { id },
+    );
+    const mood = await this.moodRepository.findOne({ where });
 
     if (!mood) {
       throw new NotFoundException(`Mood with id ${id} not found`);
@@ -35,7 +46,7 @@ export class MoodsService {
   }
 
   async update(id: string, updateMoodDto: UpdateMoodDto): Promise<Mood> {
-    const mood = await this.findOne(id);
+    const mood = await this.findOneById(id);
     const updated = this.moodRepository.merge(mood, updateMoodDto);
 
     return this.moodRepository.save(updated);
@@ -47,5 +58,15 @@ export class MoodsService {
     if (result.affected === 0) {
       throw new NotFoundException(`Mood with id ${id} not found`);
     }
+  }
+
+  private async findOneById(id: string): Promise<Mood> {
+    const mood = await this.moodRepository.findOne({ where: { id } });
+
+    if (!mood) {
+      throw new NotFoundException(`Mood with id ${id} not found`);
+    }
+
+    return mood;
   }
 }

--- a/src/moods/test/moods.controller.spec.ts
+++ b/src/moods/test/moods.controller.spec.ts
@@ -4,6 +4,7 @@ import { MoodsController } from '../moods.controller';
 import { MoodsService } from '../moods.service';
 import { RolesGuard } from '../../auth/guards/roles.guard';
 import { User } from '../../users/entities/user.entity';
+import { Mood } from '../entities/mood.entity';
 
 describe('MoodsController', () => {
   let controller: MoodsController;
@@ -16,6 +17,8 @@ describe('MoodsController', () => {
   };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MoodsController],
       providers: [
@@ -33,5 +36,30 @@ describe('MoodsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should delegate mood list reads with the current user id', async () => {
+    const currentUser = { id: 'user-1' } as User;
+    const moods = [{ id: 'mood-id' }] as Mood[];
+
+    mockMoodsService.findAll.mockResolvedValue(moods);
+
+    const result = await controller.findAll(currentUser);
+
+    expect(mockMoodsService.findAll).toHaveBeenCalledWith(currentUser);
+    expect(result).toEqual(moods);
+  });
+
+  it('should delegate single mood reads with the current user id', async () => {
+    const moodId = '550e8400-e29b-41d4-a716-446655440000';
+    const currentUser = { id: 'user-1' } as User;
+    const mood = { id: moodId } as Mood;
+
+    mockMoodsService.findOne.mockResolvedValue(mood);
+
+    const result = await controller.findOne(currentUser, moodId);
+
+    expect(mockMoodsService.findOne).toHaveBeenCalledWith(moodId, currentUser);
+    expect(result).toEqual(mood);
   });
 });

--- a/src/moods/test/moods.service.spec.ts
+++ b/src/moods/test/moods.service.spec.ts
@@ -2,6 +2,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { MoodsService } from '../moods.service';
 import { Mood } from '../entities/mood.entity';
+import { NotFoundException } from '@nestjs/common';
+import { RoleName } from '../../roles/entities/role.entity';
+import { User } from '../../users/entities/user.entity';
 
 describe('MoodsService', () => {
   let service: MoodsService;
@@ -16,6 +19,8 @@ describe('MoodsService', () => {
   };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MoodsService,
@@ -31,5 +36,99 @@ describe('MoodsService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should return only moods owned by the current user', async () => {
+    const currentUser = {
+      id: 'user-uuid',
+      roles: [{ name: RoleName.USER }],
+    } as User;
+    const moods = [
+      {
+        id: 'mood-id',
+        userId: currentUser.id,
+      },
+    ] as Mood[];
+
+    mockMoodRepository.find.mockResolvedValue(moods);
+
+    const result = await service.findAll(currentUser);
+
+    expect(mockMoodRepository.find).toHaveBeenCalledWith({
+      where: { userId: currentUser.id },
+    });
+    expect(result).toEqual(moods);
+  });
+
+  it('should return moods from all users for admins', async () => {
+    const currentUser = {
+      id: 'admin-uuid',
+      roles: [{ name: RoleName.ADMIN }],
+    } as User;
+    const moods = [{ id: 'mood-id' }] as Mood[];
+
+    mockMoodRepository.find.mockResolvedValue(moods);
+
+    const result = await service.findAll(currentUser);
+
+    expect(mockMoodRepository.find).toHaveBeenCalledWith({
+      where: undefined,
+    });
+    expect(result).toEqual(moods);
+  });
+
+  it('should return one mood only when it belongs to the current user', async () => {
+    const moodId = '550e8400-e29b-41d4-a716-446655440000';
+    const currentUser = {
+      id: 'user-uuid',
+      roles: [{ name: RoleName.USER }],
+    } as User;
+    const mood = {
+      id: moodId,
+      userId: currentUser.id,
+    } as Mood;
+
+    mockMoodRepository.findOne.mockResolvedValue(mood);
+
+    const result = await service.findOne(moodId, currentUser);
+
+    expect(mockMoodRepository.findOne).toHaveBeenCalledWith({
+      where: { id: moodId, userId: currentUser.id },
+    });
+    expect(result).toEqual(mood);
+  });
+
+  it('should return one mood by id for admins', async () => {
+    const moodId = '550e8400-e29b-41d4-a716-446655440000';
+    const currentUser = {
+      id: 'admin-uuid',
+      roles: [{ name: RoleName.ADMIN }],
+    } as User;
+    const mood = {
+      id: moodId,
+    } as Mood;
+
+    mockMoodRepository.findOne.mockResolvedValue(mood);
+
+    const result = await service.findOne(moodId, currentUser);
+
+    expect(mockMoodRepository.findOne).toHaveBeenCalledWith({
+      where: { id: moodId },
+    });
+    expect(result).toEqual(mood);
+  });
+
+  it('should reject when a mood does not belong to the current user', async () => {
+    const moodId = '550e8400-e29b-41d4-a716-446655440000';
+    const currentUser = {
+      id: 'user-uuid',
+      roles: [{ name: RoleName.USER }],
+    } as User;
+
+    mockMoodRepository.findOne.mockResolvedValue(null);
+
+    await expect(service.findOne(moodId, currentUser)).rejects.toThrow(
+      NotFoundException,
+    );
   });
 });

--- a/test/items.e2e-spec.ts
+++ b/test/items.e2e-spec.ts
@@ -203,7 +203,44 @@ describe('ItemsController (e2e)', () => {
         .expect(200)
         .expect(items);
 
-      expect(mockItemsService.findAll).toHaveBeenCalled();
+      expect(mockItemsService.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'regular-user-id' }),
+      );
+    });
+  });
+
+  describe('GET /items/:id', () => {
+    const itemId = '550e8400-e29b-41d4-a716-446655440000';
+
+    it('returns 401 when no token is provided', async () => {
+      await request(app.getHttpServer()).get(`/items/${itemId}`).expect(401);
+
+      expect(mockItemsService.findOne).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 when a valid token is provided', async () => {
+      const item = {
+        id: itemId,
+        title: 'Buy groceries',
+        description: 'Need to buy milk, eggs, and bread',
+        status: STATUS.PLANNED,
+        priority: 3,
+        listId: '550e8400-e29b-41d4-a716-446655440000',
+        targetDate: '2026-03-10',
+      };
+
+      mockItemsService.findOne.mockResolvedValue(item);
+
+      await request(app.getHttpServer())
+        .get(`/items/${itemId}`)
+        .set('Authorization', 'Bearer owner-token')
+        .expect(200)
+        .expect(item);
+
+      expect(mockItemsService.findOne).toHaveBeenCalledWith(
+        itemId,
+        expect.objectContaining({ id: 'owner-user-id' }),
+      );
     });
   });
 

--- a/test/lists.e2e-spec.ts
+++ b/test/lists.e2e-spec.ts
@@ -207,7 +207,7 @@ describe('ListsController (e2e)', () => {
         .expect(paginatedLists);
 
       expect(mockListsService.findAll).toHaveBeenCalledWith(
-        'regular-user-id',
+        expect.objectContaining({ id: 'regular-user-id' }),
         2,
         5,
       );

--- a/test/moods.e2e-spec.ts
+++ b/test/moods.e2e-spec.ts
@@ -191,7 +191,42 @@ describe('MoodsController (e2e)', () => {
         .expect(200)
         .expect(moods);
 
-      expect(mockMoodsService.findAll).toHaveBeenCalled();
+      expect(mockMoodsService.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'regular-user-id' }),
+      );
+    });
+  });
+
+  describe('GET /moods/:id', () => {
+    const moodId = '550e8400-e29b-41d4-a716-446655440000';
+
+    it('returns 401 when no token is provided', async () => {
+      await request(app.getHttpServer()).get(`/moods/${moodId}`).expect(401);
+
+      expect(mockMoodsService.findOne).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 when a valid token is provided', async () => {
+      const mood = {
+        id: moodId,
+        mood: 'happy',
+        note: 'Had a productive day and felt energized.',
+        date: '2026-02-18',
+        userId: 'regular-user-id',
+      };
+
+      mockMoodsService.findOne.mockResolvedValue(mood);
+
+      await request(app.getHttpServer())
+        .get(`/moods/${moodId}`)
+        .set('Authorization', 'Bearer user-token')
+        .expect(200)
+        .expect(mood);
+
+      expect(mockMoodsService.findOne).toHaveBeenCalledWith(
+        moodId,
+        expect.objectContaining({ id: 'regular-user-id' }),
+      );
     });
   });
 });


### PR DESCRIPTION
What

Restricts findAll / findOne read access on Lists, Items, and Moods so users only see their own records, while Admins retain full access.

Why

Previously, these endpoints returned all records regardless of the requesting user, leaking other users' data. This scope reads to the authenticated owner, with an Admin bypass.

Changes

Shared authorization helper

- [x] Added src/common/authorization/owner-scoped-query.util.ts with:
  - isAdminUser(user): checks whether the user holds the ADMIN role
  - getOwnerScopedWhere(currentUser, ownerWhere, adminWhere?): returns the owner-scoped where for regular users and the (optional, unscoped) admin where for Admins

Lists

- [x] findAll / findOne now accept the full User instead of userId and scope results via getOwnerScopedWhere (Admins get all)
- [x] Controller passes user through to both methods; update updated to call findOne(id, currentUser)

Items

- [x] findAll / findOne now require currentUser and scope by list.userId (Admins bypass the filter)
- [x] Controller injects @CurrentUser() into findAll / findOne
- [x] Extracted a private findOneById for internal, unscoped lookups (used by update) so ownership scoping doesn't break internal flows
- [x] Refactored the inline admin-role check in updateStatus to use the shared isAdminUser helper

Moods

- [x] findAll / findOne now require currentUser and scope by userId (Admins bypass)
- [x] Controller injects @CurrentUser() into findAll / findOne
- [x] Added private findOneById for internal unscoped lookups (used by update)

Tests

- [x] Added unit tests for owner-scoped-query.util
- [x] Updated + extended service and controller specs for Lists, Items, and Moods (owner-scoping + admin-bypass cases)
- [x] Updated e2e specs for items, lists, and moods